### PR TITLE
changed url for jtockauth since that was going to localhost

### DIFF
--- a/src/modules/authentication.js
+++ b/src/modules/authentication.js
@@ -1,7 +1,7 @@
 import JtockAuth from "j-tockauth";
 
 const auth = new JtockAuth({
-  host: "http://localhost:3000",
+  host: "https://the-helping-hand.herokuapp.com/",
   prefixUrl: "/api/v1",
 });
 


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172372486)
```
As a user
To be able to use the live site
I would like the sites to connect to eachother
```
## Changes proposed in this pull request:
* Changed j-tockauth url to heroku
